### PR TITLE
Rails.configuration is shortcut of Rails.application.config

### DIFF
--- a/rails.md
+++ b/rails.md
@@ -32,7 +32,7 @@ Rails
 
 ### .configuretion
 
-Rails.application.configuration のショートカット。
+Rails.application.config のショートカット。
 
 
 ### .backtrace_cleaner


### PR DESCRIPTION
Rails.configuration calls application.config in self.

http://api.rubyonrails.org/classes/Rails.html#method-i-configuration

This is wrong, please reject this pull request.
